### PR TITLE
Add transactionalId to coordinate idempotent sends across Producers

### DIFF
--- a/src/main/java/io/dropwizard/kafka/KafkaProducerFactory.java
+++ b/src/main/java/io/dropwizard/kafka/KafkaProducerFactory.java
@@ -85,6 +85,9 @@ public abstract class KafkaProducerFactory<K, V> extends KafkaClientFactory impl
     @JsonProperty
     protected boolean enableIdempotence = false;
 
+    @JsonProperty
+    protected Optional<String> transactionalId = Optional.empty();
+
     public SerializerFactory getKeySerializer() {
         return keySerializer;
     }
@@ -197,6 +200,14 @@ public abstract class KafkaProducerFactory<K, V> extends KafkaClientFactory impl
         this.enableIdempotence = enableIdempotence;
     }
 
+    public Optional<String> getTransactionalId() {
+        return transactionalId;
+    }
+
+    public void setTransactionalId(final Optional<String> transactionalId) {
+        this.transactionalId = transactionalId;
+    }
+
     protected Map<String, Object> createBaseKafkaConfigurations() {
         final Map<String, Object> config = new HashMap<>();
 
@@ -213,6 +224,7 @@ public abstract class KafkaProducerFactory<K, V> extends KafkaClientFactory impl
                 config.put(ProducerConfig.MAX_BLOCK_MS_CONFIG, maxPollBlockTimeValue.toMilliseconds()));
         clientDNSLookup.ifPresent(clientIdValue -> config.put(CommonClientConfigs.CLIENT_DNS_LOOKUP_CONFIG, clientIdValue));
         clientId.ifPresent(clientIdValue -> config.put(CommonClientConfigs.CLIENT_ID_CONFIG, clientIdValue));
+        transactionalId.ifPresent(transactionalIdValue -> config.put(ProducerConfig.TRANSACTIONAL_ID_CONFIG, transactionalIdValue));
 
         config.put(ProducerConfig.COMPRESSION_TYPE_CONFIG, compressionType);
         config.put(ProducerConfig.SEND_BUFFER_CONFIG, sendBufferBytes);

--- a/src/test/resources/yaml/basic-producer.yaml
+++ b/src/test/resources/yaml/basic-producer.yaml
@@ -14,6 +14,8 @@ maxInFlightRequestsPerConnection: 1
 maxPollBlockTime: 20s
 linger: 0ms
 requestTimeout: 30s
+enableIdempotence: true
+transactionalId: testId
 security:
   securityProtocol: sasl_ssl
   sslProtocol: TLSv1.2


### PR DESCRIPTION
Profuse apologies for missing this setting! I can certainly wait for a new version, my mistake for the miss and I appreciate very much your help. Our use case involves coordinating idempotent sends across multiple application instances:

`This enables reliability semantics which span multiple producer sessions since it allows the client to guarantee that transactions using the same TransactionalId have been completed prior to starting any new transactions.`