### PR TITLE
Mock Kafka Factory types

### DIFF
--- a/src/main/java/io/dropwizard/kafka/MockKafkaConsumerFactory.java
+++ b/src/main/java/io/dropwizard/kafka/MockKafkaConsumerFactory.java
@@ -6,6 +6,8 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 import io.dropwizard.lifecycle.setup.LifecycleEnvironment;
 import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.consumer.ConsumerRebalanceListener;
+import org.apache.kafka.clients.consumer.MockConsumer;
+import org.apache.kafka.clients.consumer.OffsetResetStrategy;
 
 import javax.annotation.Nullable;
 import java.util.Map;
@@ -14,7 +16,7 @@ import java.util.Map;
 public class MockKafkaConsumerFactory<K, V> extends KafkaConsumerFactory<K, V> {
     @Override
     public Consumer<K, V> build(LifecycleEnvironment lifecycle, HealthCheckRegistry healthChecks, @Nullable Tracing tracing, @Nullable ConsumerRebalanceListener rebalanceListener, Map<String, Object> configOverrides) {
-        return null; // no-op
+        return new MockConsumer<>(OffsetResetStrategy.EARLIEST);
     }
 
     @Override

--- a/src/main/java/io/dropwizard/kafka/MockKafkaConsumerFactory.java
+++ b/src/main/java/io/dropwizard/kafka/MockKafkaConsumerFactory.java
@@ -1,0 +1,24 @@
+package io.dropwizard.kafka;
+
+import brave.Tracing;
+import com.codahale.metrics.health.HealthCheckRegistry;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import io.dropwizard.lifecycle.setup.LifecycleEnvironment;
+import org.apache.kafka.clients.consumer.Consumer;
+import org.apache.kafka.clients.consumer.ConsumerRebalanceListener;
+
+import javax.annotation.Nullable;
+import java.util.Map;
+
+@JsonTypeName("mock")
+public class MockKafkaConsumerFactory<K, V> extends KafkaConsumerFactory<K, V> {
+    @Override
+    public Consumer<K, V> build(LifecycleEnvironment lifecycle, HealthCheckRegistry healthChecks, @Nullable Tracing tracing, @Nullable ConsumerRebalanceListener rebalanceListener, Map<String, Object> configOverrides) {
+        return null; // no-op
+    }
+
+    @Override
+    public boolean isValidConfiguration() {
+        return true;
+    }
+}

--- a/src/main/java/io/dropwizard/kafka/MockKafkaProducerFactory.java
+++ b/src/main/java/io/dropwizard/kafka/MockKafkaProducerFactory.java
@@ -4,6 +4,7 @@ import brave.Tracing;
 import com.codahale.metrics.health.HealthCheckRegistry;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import io.dropwizard.lifecycle.setup.LifecycleEnvironment;
+import org.apache.kafka.clients.producer.MockProducer;
 import org.apache.kafka.clients.producer.Producer;
 
 import javax.annotation.Nullable;
@@ -14,7 +15,7 @@ import java.util.Map;
 public class MockKafkaProducerFactory<K, V> extends KafkaProducerFactory<K, V> {
     @Override
     public Producer<K, V> build(LifecycleEnvironment lifecycle, HealthCheckRegistry healthChecks, Collection<String> topics, @Nullable Tracing tracing, Map<String, Object> configOverrides) {
-        return null;
+        return new MockProducer<>();
     }
 
     @Override

--- a/src/main/java/io/dropwizard/kafka/MockKafkaProducerFactory.java
+++ b/src/main/java/io/dropwizard/kafka/MockKafkaProducerFactory.java
@@ -1,0 +1,24 @@
+package io.dropwizard.kafka;
+
+import brave.Tracing;
+import com.codahale.metrics.health.HealthCheckRegistry;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import io.dropwizard.lifecycle.setup.LifecycleEnvironment;
+import org.apache.kafka.clients.producer.Producer;
+
+import javax.annotation.Nullable;
+import java.util.Collection;
+import java.util.Map;
+
+@JsonTypeName("mock")
+public class MockKafkaProducerFactory<K, V> extends KafkaProducerFactory<K, V> {
+    @Override
+    public Producer<K, V> build(LifecycleEnvironment lifecycle, HealthCheckRegistry healthChecks, Collection<String> topics, @Nullable Tracing tracing, Map<String, Object> configOverrides) {
+        return null;
+    }
+
+    @Override
+    public boolean isValidConfiguration() {
+        return true;
+    }
+}

--- a/src/main/resources/META-INF/services/io.dropwizard.kafka.KafkaConsumerFactory
+++ b/src/main/resources/META-INF/services/io.dropwizard.kafka.KafkaConsumerFactory
@@ -1,1 +1,2 @@
 io.dropwizard.kafka.BasicKafkaConsumerFactory
+io.dropwizard.kafka.MockKafkaConsumerFactory

--- a/src/main/resources/META-INF/services/io.dropwizard.kafka.KafkaProducerFactory
+++ b/src/main/resources/META-INF/services/io.dropwizard.kafka.KafkaProducerFactory
@@ -1,1 +1,2 @@
 io.dropwizard.kafka.BasicKafkaProducerFactory
+io.dropwizard.kafka.MockKafkaProducerFactory

--- a/src/test/java/io/dropwizard/kafka/MockKafkaConsumerFactoryTest.java
+++ b/src/test/java/io/dropwizard/kafka/MockKafkaConsumerFactoryTest.java
@@ -1,0 +1,15 @@
+package io.dropwizard.kafka;
+
+import io.dropwizard.jackson.DiscoverableSubtypeResolver;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class MockKafkaConsumerFactoryTest {
+
+    @Test
+    public void isDiscoverable() {
+        assertThat(new DiscoverableSubtypeResolver().getDiscoveredSubtypes())
+                .contains(MockKafkaConsumerFactory.class);
+    }
+}

--- a/src/test/java/io/dropwizard/kafka/MockKafkaProducerFactoryTest.java
+++ b/src/test/java/io/dropwizard/kafka/MockKafkaProducerFactoryTest.java
@@ -1,0 +1,15 @@
+package io.dropwizard.kafka;
+
+import io.dropwizard.jackson.DiscoverableSubtypeResolver;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class MockKafkaProducerFactoryTest {
+
+    @Test
+    public void isDiscoverable() {
+        assertThat(new DiscoverableSubtypeResolver().getDiscoveredSubtypes())
+                .contains(MockKafkaProducerFactory.class);
+    }
+}


### PR DESCRIPTION
Hoping to add some support to make Kafka connectivity optional for our application.

Our app specifies a series of sinks for events/messages such as Kafka or our local disk. When running locally it's often helpful to forgo the Kafka sink to test other parts of the app that are less Kafka-centric.

Currently the Kafka Producers/Consumers connect to their respective configured cluster immediately on start up and the DW app will fail to boot if no connection is available. I wasn't sure how to go about adding this optional behavior but a Mock class seems like it could also be useful for testing purposes.

What do you think, is there another way I could achieve this functionality currently?

Thanks again for taking a look!