### PR TITLE
Remove maven-failsafe-plugin from pluginManagement

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -148,11 +148,6 @@
       <plugins>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-failsafe-plugin</artifactId>
-          <version>3.2.5</version>
-        </plugin>
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-enforcer-plugin</artifactId>
           <version>3.5.0</version>
         </plugin>


### PR DESCRIPTION
maven-failsafe-plugin is managed via `io.dropwizard.modules:module-parent`.
